### PR TITLE
Implement remaining FkcValidationModule constraints

### DIFF
--- a/api/src/main/java/io/fabric8/crd/generator/victools/schema/AbstractValidationModule.java
+++ b/api/src/main/java/io/fabric8/crd/generator/victools/schema/AbstractValidationModule.java
@@ -27,8 +27,8 @@ public abstract class AbstractValidationModule implements Module {
     builder.forFields().withNumberExclusiveMaximumResolver(this::resolveNumberExclusiveMaximum);
 
     builder.forFields().withStringPatternResolver(this::resolvePattern);
-    builder.forMethods().withStringMinLengthResolver(this::resolveStringMinLength);
-    builder.forMethods().withStringMaxLengthResolver(this::resolveStringMaxLength);
+    builder.forFields().withStringMinLengthResolver(this::resolveStringMinLength);
+    builder.forFields().withStringMaxLengthResolver(this::resolveStringMaxLength);
 
     builder.forFields().withArrayMinItemsResolver(this::resolveArrayMinItems);
     builder.forFields().withArrayMaxItemsResolver(this::resolveArrayMaxItems);
@@ -95,6 +95,28 @@ public abstract class AbstractValidationModule implements Module {
       overridePropertyCountAttribute(attributes,
           context.getKeyword(SchemaKeyword.TAG_PROPERTIES_MAX),
           resolveMapMaxEntries(member), Math::max);
+    }
+
+    // Kubernetes structural schemas (apiextensions.k8s.io/v1) follow JSON Schema
+    // draft-4: exclusiveMinimum/exclusiveMaximum are booleans modifying
+    // minimum/maximum. victools emits draft-6 numeric values, so translate them.
+    rewriteExclusiveBoundToKubernetes(attributes,
+        context.getKeyword(SchemaKeyword.TAG_MINIMUM_EXCLUSIVE),
+        context.getKeyword(SchemaKeyword.TAG_MINIMUM));
+    rewriteExclusiveBoundToKubernetes(attributes,
+        context.getKeyword(SchemaKeyword.TAG_MAXIMUM_EXCLUSIVE),
+        context.getKeyword(SchemaKeyword.TAG_MAXIMUM));
+  }
+
+  private void rewriteExclusiveBoundToKubernetes(
+      ObjectNode attributes,
+      String exclusiveAttribute,
+      String inclusiveAttribute) {
+
+    JsonNode exclusiveValue = attributes.get(exclusiveAttribute);
+    if (exclusiveValue != null && exclusiveValue.isNumber()) {
+      attributes.set(inclusiveAttribute, exclusiveValue);
+      attributes.put(exclusiveAttribute, true);
     }
   }
 

--- a/api/src/main/java/io/fabric8/crd/generator/victools/schema/fkc/FkcValidationModule.java
+++ b/api/src/main/java/io/fabric8/crd/generator/victools/schema/fkc/FkcValidationModule.java
@@ -10,12 +10,14 @@ import io.fabric8.generator.annotation.Min;
 import io.fabric8.generator.annotation.Nullable;
 import io.fabric8.generator.annotation.Pattern;
 import io.fabric8.generator.annotation.Required;
+import io.fabric8.generator.annotation.Size;
 import lombok.extern.slf4j.Slf4j;
 
 import java.math.BigDecimal;
 
 import static io.fabric8.crd.generator.victools.schema.SchemaGeneratorUtils.findAnnotationOnFieldAndGetter;
 import static io.fabric8.crd.generator.victools.schema.SchemaGeneratorUtils.findAnnotationOnFieldGetterContainerItem;
+import static java.util.function.Predicate.not;
 
 /**
  * Module for common validation constraints, declared by Fabric8 annotations.
@@ -54,6 +56,7 @@ public class FkcValidationModule extends AbstractValidationModule {
   protected BigDecimal resolveNumberInclusiveMinimum(MemberScope<?, ?> member) {
     if (!member.getType().isInstanceOf(CharSequence.class)) {
       return findAnnotationOnFieldGetterContainerItem(member, Min.class)
+          .filter(Min::inclusive)
           .map(Min::value)
           .map(BigDecimal::valueOf)
           .orElse(null);
@@ -63,7 +66,13 @@ public class FkcValidationModule extends AbstractValidationModule {
 
   @Override
   protected BigDecimal resolveNumberExclusiveMinimum(MemberScope<?, ?> member) {
-    // TODO: not yet supported
+    if (!member.getType().isInstanceOf(CharSequence.class)) {
+      return findAnnotationOnFieldGetterContainerItem(member, Min.class)
+          .filter(not(Min::inclusive))
+          .map(Min::value)
+          .map(BigDecimal::valueOf)
+          .orElse(null);
+    }
     return null;
   }
 
@@ -71,6 +80,7 @@ public class FkcValidationModule extends AbstractValidationModule {
   protected BigDecimal resolveNumberInclusiveMaximum(MemberScope<?, ?> member) {
     if (!member.getType().isInstanceOf(CharSequence.class)) {
       return findAnnotationOnFieldGetterContainerItem(member, Max.class)
+          .filter(Max::inclusive)
           .map(Max::value)
           .map(BigDecimal::valueOf)
           .orElse(null);
@@ -80,7 +90,13 @@ public class FkcValidationModule extends AbstractValidationModule {
 
   @Override
   protected BigDecimal resolveNumberExclusiveMaximum(MemberScope<?, ?> member) {
-    // TODO: not yet supported
+    if (!member.getType().isInstanceOf(CharSequence.class)) {
+      return findAnnotationOnFieldGetterContainerItem(member, Max.class)
+          .filter(not(Max::inclusive))
+          .map(Max::value)
+          .map(BigDecimal::valueOf)
+          .orElse(null);
+    }
     return null;
   }
 
@@ -97,7 +113,11 @@ public class FkcValidationModule extends AbstractValidationModule {
   @Override
   protected Integer resolveArrayMinItems(MemberScope<?, ?> member) {
     if (member.isContainerType()) {
-      // TODO: not yet supported
+      return findAnnotationOnFieldGetterContainerItem(member, Size.class)
+          .map(Size::min)
+          .filter(min -> min > 0)
+          .map(Math::toIntExact)
+          .orElse(null);
     }
     return null;
   }
@@ -105,7 +125,11 @@ public class FkcValidationModule extends AbstractValidationModule {
   @Override
   protected Integer resolveArrayMaxItems(MemberScope<?, ?> member) {
     if (member.isContainerType()) {
-      // TODO: not yet supported
+      return findAnnotationOnFieldGetterContainerItem(member, Size.class)
+          .map(Size::max)
+          .filter(max -> max < Integer.MAX_VALUE)
+          .map(Math::toIntExact)
+          .orElse(null);
     }
     return null;
   }
@@ -113,7 +137,11 @@ public class FkcValidationModule extends AbstractValidationModule {
   @Override
   protected Integer resolveStringMinLength(MemberScope<?, ?> member) {
     if (member.getType().isInstanceOf(CharSequence.class)) {
-      // TODO: not yet supported
+      return findAnnotationOnFieldGetterContainerItem(member, Size.class)
+          .map(Size::min)
+          .filter(min -> min > 0)
+          .map(Math::toIntExact)
+          .orElse(null);
     }
     return null;
   }
@@ -121,21 +149,31 @@ public class FkcValidationModule extends AbstractValidationModule {
   @Override
   protected Integer resolveStringMaxLength(MemberScope<?, ?> member) {
     if (member.getType().isInstanceOf(CharSequence.class)) {
-      // TODO: not yet supported
+      return findAnnotationOnFieldGetterContainerItem(member, Size.class)
+          .map(Size::max)
+          .filter(max -> max < Integer.MAX_VALUE)
+          .map(Math::toIntExact)
+          .orElse(null);
     }
     return null;
   }
 
   @Override
   protected Integer resolveMapMinEntries(MemberScope<?, ?> member) {
-    // TODO: not yet supported
-    return null;
+    return findAnnotationOnFieldGetterContainerItem(member, Size.class)
+        .map(Size::min)
+        .filter(min -> min > 0)
+        .map(Math::toIntExact)
+        .orElse(null);
   }
 
   @Override
   protected Integer resolveMapMaxEntries(MemberScope<?, ?> member) {
-    // TODO: not yet supported
-    return null;
+    return findAnnotationOnFieldGetterContainerItem(member, Size.class)
+        .map(Size::max)
+        .filter(max -> max < Integer.MAX_VALUE)
+        .map(Math::toIntExact)
+        .orElse(null);
   }
 
 }

--- a/test/src/test/java/io/fabric8/crd/generator/victools/approvaltests/validation/FkcValidationSpec.java
+++ b/test/src/test/java/io/fabric8/crd/generator/victools/approvaltests/validation/FkcValidationSpec.java
@@ -3,7 +3,11 @@ package io.fabric8.crd.generator.victools.approvaltests.validation;
 import io.fabric8.generator.annotation.Max;
 import io.fabric8.generator.annotation.Min;
 import io.fabric8.generator.annotation.Pattern;
+import io.fabric8.generator.annotation.Size;
 import lombok.Data;
+
+import java.util.List;
+import java.util.Map;
 
 /**
  * Tests for Fabric8 validation annotations
@@ -20,6 +24,8 @@ public class FkcValidationSpec {
   private ValidationOnDouble onDouble;
   private ValidationOnDoublePrim onDoublePrim;
   private ValidationOnString onString;
+  private ValidationExclusive onExclusive;
+  private ValidationSize onSize;
 
   @Data
   static class ValidationOnInteger {
@@ -113,6 +119,27 @@ public class FkcValidationSpec {
   static class ValidationOnString {
     @Pattern("(a|b)+")
     private String pattern;
+  }
+
+  @Data
+  static class ValidationExclusive {
+    @Min(value = 1, inclusive = false)
+    private Integer exclusiveMinimum1;
+    @Max(value = 3, inclusive = false)
+    private Integer exclusiveMaximum3;
+    @Min(value = 1, inclusive = false)
+    @Max(value = 3, inclusive = false)
+    private Integer exclusiveMinimum1Maximum3;
+  }
+
+  @Data
+  static class ValidationSize {
+    @Size(min = 1, max = 5)
+    private List<String> list;
+    @Size(min = 2, max = 10)
+    private String string;
+    @Size(min = 1, max = 4)
+    private Map<String, String> map;
   }
 
 }

--- a/test/src/test/resources/io/fabric8/crd/generator/victools/approvaltests/CRDGeneratorVictoolsApprovalTest.approvalTest.fkcvalidations.samples.fabric8.io.v1.approved.yml
+++ b/test/src/test/resources/io/fabric8/crd/generator/victools/approvaltests/CRDGeneratorVictoolsApprovalTest.approvalTest.fkcvalidations.samples.fabric8.io.v1.approved.yml
@@ -43,6 +43,23 @@ spec:
                     minimum: 1.0
                     type: "number"
                 type: "object"
+              onExclusive:
+                properties:
+                  exclusiveMaximum3:
+                    exclusiveMaximum: true
+                    maximum: 3.0
+                    type: "integer"
+                  exclusiveMinimum1:
+                    exclusiveMinimum: true
+                    minimum: 1.0
+                    type: "integer"
+                  exclusiveMinimum1Maximum3:
+                    exclusiveMaximum: true
+                    exclusiveMinimum: true
+                    maximum: 3.0
+                    minimum: 1.0
+                    type: "integer"
+                type: "object"
               onFloat:
                 properties:
                   maximum1:
@@ -120,6 +137,25 @@ spec:
                     maximum: 3.0
                     minimum: 1.0
                     type: "integer"
+                type: "object"
+              onSize:
+                properties:
+                  list:
+                    items:
+                      type: "string"
+                    maxItems: 5
+                    minItems: 1
+                    type: "array"
+                  map:
+                    additionalProperties:
+                      type: "string"
+                    maxProperties: 4
+                    minProperties: 1
+                    type: "object"
+                  string:
+                    maxLength: 10
+                    minLength: 2
+                    type: "string"
                 type: "object"
               onString:
                 properties:

--- a/test/src/test/resources/io/fabric8/crd/generator/victools/approvaltests/CRDGeneratorVictoolsApprovalTest.approvalTest.fkcvalidations.samples.fabric8.io.v1.v1alpha1.approved.json
+++ b/test/src/test/resources/io/fabric8/crd/generator/victools/approvaltests/CRDGeneratorVictoolsApprovalTest.approvalTest.fkcvalidations.samples.fabric8.io.v1.v1alpha1.approved.json
@@ -38,6 +38,28 @@
           },
           "type" : "object"
         },
+        "onExclusive" : {
+          "properties" : {
+            "exclusiveMaximum3" : {
+              "exclusiveMaximum" : true,
+              "maximum" : 3.0,
+              "type" : "integer"
+            },
+            "exclusiveMinimum1" : {
+              "exclusiveMinimum" : true,
+              "minimum" : 1.0,
+              "type" : "integer"
+            },
+            "exclusiveMinimum1Maximum3" : {
+              "exclusiveMaximum" : true,
+              "exclusiveMinimum" : true,
+              "maximum" : 3.0,
+              "minimum" : 1.0,
+              "type" : "integer"
+            }
+          },
+          "type" : "object"
+        },
         "onFloat" : {
           "properties" : {
             "maximum1" : {
@@ -142,6 +164,32 @@
               "maximum" : 3.0,
               "minimum" : 1.0,
               "type" : "integer"
+            }
+          },
+          "type" : "object"
+        },
+        "onSize" : {
+          "properties" : {
+            "list" : {
+              "items" : {
+                "type" : "string"
+              },
+              "maxItems" : 5,
+              "minItems" : 1,
+              "type" : "array"
+            },
+            "map" : {
+              "additionalProperties" : {
+                "type" : "string"
+              },
+              "maxProperties" : 4,
+              "minProperties" : 1,
+              "type" : "object"
+            },
+            "string" : {
+              "maxLength" : 10,
+              "minLength" : 2,
+              "type" : "string"
             }
           },
           "type" : "object"


### PR DESCRIPTION
Implement the stubbed resolvers in FkcValidationModule (exclusive numeric min/max, array minItems/maxItems, string minLength/maxLength, map minProperties/maxProperties).